### PR TITLE
add multiplier option to scheduler

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -64,7 +64,7 @@ requests-oauthlib==1.3.0
 retrying==1.3.3
 rope==0.17.0
 rsa==4.0
-schedule==0.6.0
+schedule==1.0.0
 sheetfu==1.5.3
 six==1.14.0
 SQLAlchemy==1.3.17

--- a/src/consts.py
+++ b/src/consts.py
@@ -42,6 +42,7 @@ STRINGS_DB_CONFIG = 'strings'
 # Jobs-related keys
 EVERY = 'every'
 AT = 'at'
+MULT = 'mult'
 SEND_TO = 'send_to'
 KWARGS = 'kwargs'
 

--- a/src/scheduler.py
+++ b/src/scheduler.py
@@ -9,7 +9,7 @@ import telegram
 
 from .app_context import AppContext
 from .config_manager import ConfigManager
-from .consts import CONFIG_RELOAD_MINUTES, EVERY, AT, SEND_TO, KWARGS
+from .consts import CONFIG_RELOAD_MINUTES, EVERY, AT, MULT, SEND_TO, KWARGS
 from .jobs.utils import get_job_runnable
 from .tg.sender import TelegramSender
 from .utils.singleton import Singleton
@@ -75,8 +75,18 @@ class JobScheduler(Singleton):
                 schedules = [schedules]
             for schedule_dict in schedules:
                 try:
-                    scheduled = getattr(schedule.every(), schedule_dict[EVERY])
-                    if 'at' in schedule_dict:
+                    if MULT in schedule_dict:
+                        multiplier = schedule_dict[MULT]
+                        assert 0 < multiplier
+                        # e.g. schedule.every(10).minutes
+                        scheduled = getattr(schedule.every(multiplier), schedule_dict[EVERY])
+                    else:
+                        # e.g. schedule.every().hour
+                        scheduled = getattr(schedule.every(), schedule_dict[EVERY])
+                    if AT in schedule_dict:
+                        # can't set "every 10 minutes" and "at 10:00" at the same time
+                        assert MULT not in schedule_dict
+                        # e.g. schedule.every().wednesday.at("10:00")
                         scheduled = scheduled.at(schedule_dict[AT])
                     scheduled.do(
                         get_job_runnable(job_id),


### PR DESCRIPTION
Now two options are available:

`{"every": "minute"}` - once a minute
vs
`{"mult": 10, every: "minutes"}` - every 10 minutes

Note the plural form for "every" parameter!