### PR TITLE
Fix the average count because it now outputs errors (division by zero)

### DIFF
--- a/src/instagram/instagram_client.py
+++ b/src/instagram/instagram_client.py
@@ -113,6 +113,8 @@ class InstagramClient(Singleton):
         Get the average number of likes on recent posts.
         """
         posts = self._get_new_posts(since, until)
+        if len(posts) == 0:
+            return 0
         return int(sum(map(lambda post: post.like_count, posts)) / len(posts))
 
     def get_comments_count(self, since: datetime, until: datetime) -> int:


### PR DESCRIPTION
Fixes the following error in the bot's log:
`
ERROR - base_job - Could not run job IGAnalyticsReportJob - Traceback (most recent call last):
  File "/app/src/jobs/base_job.py", line 36, in execute
    **kwargs if kwargs else {}
  File "/app/src/jobs/ig_analytics_report_job.py", line 50, in _execute
    week_ago, end_week_day
  File "/app/src/analytics/api_instagram_analytics.py", line 37, in get_likes_avg
    return self._ig_client.get_likes_avg(since, until)
  File "/app/src/instagram/instagram_client.py", line 116, in get_likes_avg
    return int(sum(map(lambda post: post.like_count, posts)) / len(posts))
ZeroDivisionError: division by zero
`