### PR TITLE
feat: match focalboard username to telegram

### DIFF
--- a/src/db/db_client.py
+++ b/src/db/db_client.py
@@ -137,7 +137,7 @@ class DBClient(Singleton):
     def find_author_telegram_by_trello(self, trello_id: str):
         # TODO: make batch queries
         session = self.Session()
-        author = session.query(Author).filter(Author.trello == trello_id).first()
+        author = session.query(Author).filter((Author.trello == trello_id) | (Author.focalboard == trello_id)).first()
         if author is None:
             logger.warning(f"Telegram id not found for author {trello_id}")
             return None

--- a/src/db/db_objects.py
+++ b/src/db/db_objects.py
@@ -14,9 +14,10 @@ class Author(Base):
     status = Column(String)
     telegram = Column(String)
     trello = Column(String)
+    focalboard = Column(String)
 
     def __repr__(self):
-        return f"Author {self.name} tg={self.telegram} trello={self.trello}"
+        return f"Author {self.name} tg={self.telegram} trello={self.trello} focalboard={self.focalboard}"
 
     @classmethod
     def from_dict(cls, data):
@@ -26,6 +27,7 @@ class Author(Base):
         author.status = _get_str_data_item(data, "status")
         author.telegram = _get_str_data_item(data, "telegram")
         author.trello = _get_str_data_item(data, "trello")
+        author.focalboard = _get_str_data_item(data, "focalboard")
         return author
 
     def to_dict(self):
@@ -35,6 +37,7 @@ class Author(Base):
             "status": self.status,
             "telegram": self.telegram,
             "trello": self.trello,
+            "focalboard": self.focalboard,
         }
 
     @classmethod
@@ -45,6 +48,7 @@ class Author(Base):
         author.status = item.get_field_value(load("sheets__status"))
         author.telegram = item.get_field_value(load("sheets__telegram"))
         author.trello = item.get_field_value(load("sheets__trello"))
+        author.focalboard = item.get_field_value(load("sheets__focalboard"))
         return author
 
 


### PR DESCRIPTION
Currently the `retrieve_username` function used in `/get_tasks_report` is able to mention Telegram users for corresponding Trello usernames. This fails if Trello username is not equal to the Focalboard username, so we want to support matching both temporarily.

Before merging:
1) add the `focalboard` column to `authors` table manually (we don't have alembic here);
2) make changes to Google Sheets (authors, team)
