### PR TITLE
feat: cheat asyncio migration

### DIFF
--- a/app.py
+++ b/app.py
@@ -14,6 +14,9 @@ from src.tg.sender import TelegramSender
 from src.utils.log_handler import ErrorBroadcastHandler
 from src.utils.uptrace_logger import add_uptrace_logging
 
+import nest_asyncio
+nest_asyncio.apply()
+
 locale.setlocale(locale.LC_TIME, "ru_RU.UTF-8")
 logging.basicConfig(format=consts.LOG_FORMAT, level=logging.INFO)
 
@@ -94,4 +97,5 @@ if __name__ == "__main__":
     try:
         get_bot().run()
     except BaseException as e:
+        print(e.with_traceback())
         report_critical_error(e)

--- a/requirements.txt
+++ b/requirements.txt
@@ -80,7 +80,7 @@ pyparsing==2.4.7
 pytest==5.4.1
 pytest-asyncio==0.12.0
 python-dateutil==2.8.1
-python-telegram-bot==12.6.1
+python-telegram-bot==21.4.0
 pytoml==0.1.21
 pytz==2020.1
 PyYAML==6.0.1

--- a/src/bot.py
+++ b/src/bot.py
@@ -54,7 +54,8 @@ class SysBlokBot:
             ApplicationBuilder()
             .persistence(PicklePersistence(filepath="persistent_storage.pickle"))
             .token(tg_config["token"])
-            .post_shutdown(signal_handler)
+            # .post_shutdown(signal_handler)
+            .concurrent_updates(True)
             .build()
         )
         self.telegram_sender = sender.TelegramSender(

--- a/src/bot.py
+++ b/src/bot.py
@@ -4,14 +4,14 @@ from collections import defaultdict
 from typing import Callable
 
 from telegram.ext import (
+    ApplicationBuilder,
     CallbackQueryHandler,
     CommandHandler,
-    Filters,
+    filters,
     MessageHandler,
     PicklePersistence,
     Updater,
 )
-from telegram.ext.dispatcher import run_async
 
 from .app_context import AppContext
 from .config_manager import ConfigManager
@@ -37,6 +37,10 @@ logging.Logger.usage = usage
 logger = logging.getLogger(__name__)
 
 
+async def async_wrap(f: Callable, *args, **kwargs):
+    return f(*args, **kwargs)
+
+
 class SysBlokBot:
     def __init__(
         self,
@@ -46,15 +50,15 @@ class SysBlokBot:
     ):
         self.config_manager = config_manager
         tg_config = config_manager.get_telegram_config()
-        self.updater = Updater(
-            tg_config["token"],
-            use_context=True,
-            user_sig_handler=signal_handler,
-            persistence=PicklePersistence(filename="persistent_storage.pickle"),
+        self.application = (
+            ApplicationBuilder()
+            .persistence(PicklePersistence(filepath="persistent_storage.pickle"))
+            .token(tg_config["token"])
+            .post_shutdown(signal_handler)
+            .build()
         )
-        self.dp = self.updater.dispatcher
         self.telegram_sender = sender.TelegramSender(
-            bot=self.dp.bot, tg_config=tg_config
+            bot=self.application.bot, tg_config=tg_config
         )
         try:
             self.app_context = AppContext(config_manager, skip_db_update)
@@ -415,33 +419,37 @@ class SysBlokBot:
         )
 
         # on non-command user message
-        self.dp.add_handler(MessageHandler(Filters.text, handlers.handle_user_message))
-        self.dp.add_handler(CallbackQueryHandler(handlers.handle_callback_query))
-        self.dp.add_handler(
+
+        def asyncify(func):
+            async def wrapper(*args, **kwargs):
+                results = func(*args, **kwargs)
+                return results
+
+            return wrapper
+
+        self.application.add_handler(MessageHandler(filters.TEXT, asyncify(handlers.handle_user_message)))
+        self.application.add_handler(CallbackQueryHandler(asyncify(handlers.handle_callback_query)))
+        self.application.add_handler(
             MessageHandler(
-                Filters.status_update.new_chat_members, handlers.handle_new_members
+                filters.StatusUpdate.NEW_CHAT_MEMBERS, asyncify(handlers.handle_new_members)
             )
         )
 
         # log all errors
-        self.dp.add_error_handler(handlers.error)
+        self.application.add_error_handler(async_wrap(handlers.error))
 
     def run(self):
         # Start the Bot
         logger.info("Starting polling...")
-        self.updater.start_polling()
-
-        # Run the bot until you press Ctrl-C or the process receives SIGINT,
-        # SIGTERM or SIGABRT. start_polling() is non-blocking and will
-        # stop the bot gracefully.
-        self.updater.idle()
+        # TODO add non-blocking runtime (graceful termination for SIGTERM etc)
+        self.application.run_polling()
 
     # Methods, adding command handlers and setting them to /help cmd for proper audience
     def add_handler(self, handler_cmd: str, handler_func: Callable):
         """Adds handler silently. Noone will see it in /help output"""
 
         def add_usage_logging(func):
-            def wrapper(*args, **kwargs):
+            async def wrapper(*args, **kwargs):
                 logger.usage(f"Handler {handler_cmd} was called...")
                 results = func(*args, **kwargs)
                 logger.usage(f"Handler {handler_cmd} finished")
@@ -449,8 +457,8 @@ class SysBlokBot:
 
             return wrapper
 
-        self.dp.add_handler(
-            CommandHandler(handler_cmd, run_async(add_usage_logging(handler_func)))
+        self.application.add_handler(
+            CommandHandler(handler_cmd, add_usage_logging(handler_func))
         )
 
     def add_admin_handler(

--- a/src/jobs/tg_analytics_report_job.py
+++ b/src/jobs/tg_analytics_report_job.py
@@ -17,17 +17,20 @@ class TgAnalyticsReportJob(BaseJob):
     def _execute(
         app_context: AppContext, send: Callable[[str], None], called_from_handler=False
     ):
-        with app_context.tg_client.api_client:
-            stats = app_context.tg_client.api_client.loop.run_until_complete(
-                app_context.tg_client.api_client.get_stats(
-                    app_context.tg_client.channel
-                )
+        app_context.tg_client.api_client.loop.run_until_complete(
+            app_context.tg_client.api_client.connect()
+        )
+        stats = app_context.tg_client.api_client.loop.run_until_complete(
+            app_context.tg_client.api_client.get_stats(
+                app_context.tg_client.channel
             )
-            entity = app_context.tg_client.api_client.loop.run_until_complete(
-                app_context.tg_client.api_client.get_entity(
-                    app_context.tg_client.channel
-                )
+        )
+        entity = app_context.tg_client.api_client.loop.run_until_complete(
+            app_context.tg_client.api_client.get_entity(
+                app_context.tg_client.channel
             )
+        )
+        app_context.tg_client.api_client.disconnect()
         new_posts_count = len(stats.recent_message_interactions)
         followers_stats = TgAnalyticsReportJob._get_followers_stats(stats)
         message = load(

--- a/src/tg/handlers/user_message_handler.py
+++ b/src/tg/handlers/user_message_handler.py
@@ -99,7 +99,7 @@ def handle_user_message(
                 trello_lists = trello_client.get_lists(board_id)
                 trello_lists = trello_lists[::-1]
         except Exception as e:
-            logger.warning(e)
+            logger.warning(e, exc_info=e)
             reply(
                 load(
                     "get_tasks_report_handler__enter_the_number",

--- a/src/tg/tg_client.py
+++ b/src/tg/tg_client.py
@@ -33,8 +33,9 @@ class TgClient(Singleton):
         )
         # we need this to properly reauth in case the tokens need to be updated
         # we need "with" to open and close the event loop
-        with self.api_client as client:
-            client(functions.auth.ResetAuthorizationsRequest())
+        # removed as part of v20.0 migration
+        # with self.api_client as client:
+        #     client(functions.auth.ResetAuthorizationsRequest())
         self.sysblok_chats = self._tg_config["sysblok_chats"]
         self.channel = self._tg_config["channel"]
 


### PR DESCRIPTION
MVP of asyncio migration (inefficient, but incremental).
* removing the cyclic `pretty_send` usage in `tg_sender`, needed because we can't use async lambda for sending the message + making `pretty_send` async would result in a need to rewrite most commands;
* using `nest_asyncio` to accommodate nested loops creation (likely a short-term solution);
* removed the `ResetAuthorizationsRequest` call during TG client init;
* rewritted the Telethon client initialisation in `src/jobs/tg_analytics_report_job.py`;
* wrap all handlers in `bot.py` in a makeshift async function.

This approach works. Most commands tested.