### PR TITLE
feat: add useful info to list jobs cmd

### DIFF
--- a/src/scheduler.py
+++ b/src/scheduler.py
@@ -11,6 +11,7 @@ from .app_context import AppContext
 from .config_manager import ConfigManager
 from .consts import AT, CONFIG_RELOAD_MINUTES, EVERY, KWARGS, SEND_TO
 from .jobs.utils import get_job_runnable
+from .strings import load
 from .tg.sender import TelegramSender
 from .utils.singleton import Singleton
 
@@ -107,8 +108,30 @@ class JobScheduler(Singleton):
         logger.info("Finished setting jobs")
 
     @staticmethod
+    def _describe_job(job: schedule.Job) -> str:
+        # copied from schedule module
+        if hasattr(job.job_func, "__name__"):
+            job_func_name = job.job_func.__name__  # type: ignore
+        else:
+            job_func_name = repr(job.job_func)
+
+        send_func = job.job_func.keywords.get("send", None)
+        recipients = ', '.join(
+            f'<a href="https://web.telegram.org/a/#{chat_id}">{chat_id}</a>'
+            for chat_id in send_func.chat_ids
+        ) if send_func else None
+
+        return load(
+            "jobs__job_description",
+            job_name=job_func_name,
+            job_time=job.at_time,
+            job_interval=job.start_day or job.interval,
+            recipients=recipients,
+        )
+
+    @staticmethod
     def list_jobs() -> List[str]:
-        return [html.escape(str(job)) for job in schedule.jobs]
+        return [JobScheduler._describe_job(job) for job in schedule.jobs]
 
     def reschedule_jobs(self):
         logger.info("Clearing all scheduled jobs...")

--- a/src/tg/sender.py
+++ b/src/tg/sender.py
@@ -46,7 +46,10 @@ class TelegramSender(Singleton):
         """
         if isinstance(chat_ids, int):
             chat_ids = [chat_ids]
-        return lambda message: self.send_to_chat_ids(message, chat_ids)
+        sender = lambda message: self.send_to_chat_ids(message, chat_ids)
+        # add destination info
+        sender.chat_ids = chat_ids
+        return sender
 
     def send_to_chat_ids(self, message_text: str, chat_ids: List[int]):
         """


### PR DESCRIPTION
before: /list_cmd would output technical information about the jobs provided by APScheduler (not very useful)

after: we explicitly store list of recipients for a job and show it along with more readable data on schedule and job name
```
👔 {job_name}
🕔 every {job_interval} at {job_time} MSK
✉️ {recipients}
```
with some extra tweaks for particular jobs such as `SendRemindersJob` which takes care of multiple reminders
```
⏰ {reminder_title}
🕔 every {reminder_interval} at {reminder_time} MSK
✉️ {recipients}
```