### PR TITLE
fix: fix all failing unit tests and add CI workflow

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,7 +2,13 @@ name: Unit tests
 
 on:
   push:
+    branches:
+      - dev
+      - master
   pull_request:
+    branches:
+      - dev
+      - master
 
 jobs:
   test:
@@ -23,4 +29,6 @@ jobs:
           pip install -r requirements.txt
 
       - name: Run unit tests
+        env:
+          PYTHONPATH: ${{ github.workspace }}:${{ github.workspace }}/tests
         run: pytest tests/unit/

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,26 @@
+name: Unit tests
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Set up Python 3.8
+        uses: actions/setup-python@v4
+        with:
+          python-version: "3.8"
+
+      - name: Install dependencies
+        run: |
+          sudo apt-get install -y git
+          pip install -r requirements.txt
+
+      - name: Run unit tests
+        run: pytest tests/unit/

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -1,16 +1,30 @@
+import logging
 import os
 from typing import Dict, List
+from unittest.mock import MagicMock
 
 import pytest
 from utils.json_loader import JsonLoader
 
 from src.config_manager import ConfigManager
+from src.consts import USAGE_LOG_LEVEL
 from src.db.db_client import DBClient
 from src.drive.drive_client import GoogleDriveClient
 from src.sheets.sheets_client import GoogleSheetsClient
 from src.strings import StringsDBClient
 from src.tg.sender import TelegramSender
 from src.trello.trello_client import TrelloClient
+
+# logger.usage is added to the Logger class in bot.py at runtime; tests never
+# import bot, so we register it here to avoid AttributeError in job logging.
+logging.addLevelName(USAGE_LOG_LEVEL, "NOTICE")
+
+
+def _usage(self, message, *args, **kws):
+    self._log(USAGE_LOG_LEVEL, message, args, **kws)
+
+
+logging.Logger.usage = _usage
 
 ROOT_TEST_DIR = os.path.abspath(os.path.dirname(__file__))
 STATIC_TEST_DIR = os.path.join(ROOT_TEST_DIR, "static")
@@ -67,20 +81,7 @@ def mock_trello(monkeypatch, mock_config_manager):
 @pytest.fixture
 def mock_sheets_client(monkeypatch, mock_config_manager):
     def _authorize(self):
-        pass
-
-    # def _parse_gs_res(_, title_key_map: Dict, sheet_key: str, sheet_name: str = '') -> List[Dict]:
-
-    #     load_json = JsonLoader(SHEETS_TEST_DIR).load_json
-
-    #     if sheet_key == 'authors_sheet_key':
-    #         return load_json('authors.json')
-    #     elif sheet_key == 'curators_sheet_key':
-    #         return load_json('curators.json')
-    #     elif sheet_key == 'rubrics_registry_sheet_key':
-    #         return load_json('rubrics.json')
-    #     elif sheet_key == 'strings_sheet_key':
-    #         return load_json('strings.json')
+        self.client = MagicMock()
 
     monkeypatch.setattr(GoogleSheetsClient, "_authorize", _authorize)
     # monkeypatch.setattr(GoogleSheetsClient, '_parse_gs_res', _parse_gs_res)

--- a/tests/unit/static/config_override.json
+++ b/tests/unit/static/config_override.json
@@ -5,7 +5,8 @@
     "trello": {
         "api_key": "stub",
         "token": "stub",
-        "board_id": "board_id"
+        "board_id": "board_id",
+        "deprecated": false
     },
     "sheets": {
         "api_key_path": "stub",

--- a/tests/unit/test_db_client.py
+++ b/tests/unit/test_db_client.py
@@ -4,22 +4,3 @@ def test_init(mock_db_client):
 
 def test_fetch_all(mock_db_client, mock_sheets_client):
     mock_db_client.fetch_all(mock_sheets_client)
-
-
-def test_find_author_telegram_by_trello(mock_db_client, mock_sheets_client):
-    mock_db_client.fetch_all(mock_sheets_client)
-    assert mock_db_client.find_author_telegram_by_trello("@merwanrim") == "@rim"
-
-
-def test_find_curators_by_author_trello(mock_db_client, mock_sheets_client):
-    mock_db_client.fetch_all(mock_sheets_client)
-    curators = mock_db_client.find_curators_by_author_trello("@merwanrim")
-    assert len(curators) == 1
-    assert curators[0].telegram == "@flo"
-
-
-def test_find_curators_by_trello_label(mock_db_client, mock_sheets_client):
-    mock_db_client.fetch_all(mock_sheets_client)
-    curators = mock_db_client.find_curators_by_trello_label("Классицизм")
-    assert len(curators) == 1
-    assert curators[0].telegram == "@flo"


### PR DESCRIPTION
- conftest.py: register logger.usage (defined in bot.py at runtime, absent in tests); mock GoogleSheetsClient.client so fetch_all doesn't AttributeError
- config_override.json: add missing "deprecated" key for TrelloClient init
- test_db_client.py: remove three tests for methods removed in PR #428 (find_curators_by_author_trello, find_curators_by_trello_label, find_author_telegram_by_trello — Author table to be dropped in follow-on PR)
- .github/workflows/test.yml: run pytest on every push and PR