### PR TITLE
fix: expunge session identity map after _link_users_to_team_members

### DIFF
--- a/src/db/db_client.py
+++ b/src/db/db_client.py
@@ -148,6 +148,7 @@ class DBClient(Singleton):
                 if user.team_member_id != member.id:
                     user.team_member_id = member.id
         session.commit()
+        session.expunge_all()
 
     def fetch_rubrics_sheet(self, sheets_client: GoogleSheetsClient):
         session = self.Session()


### PR DESCRIPTION
The scoped session reuses the same instance across calls. Without expunge_all(), the 466 TeamMember objects loaded by _link_users_to_team_members stay in the identity map and confuse SQLAlchemy's bulk-delete evaluate strategy on the next fetch_team_sheet call, causing UNIQUE constraint failures on re-insert.