### PR TITLE
fix: check Телеграм label before BLACK color filter

### DIFF
--- a/src/jobs/publication_plans_job.py
+++ b/src/jobs/publication_plans_job.py
@@ -101,7 +101,9 @@ class PublicationPlansJob(BaseJob):
             ]
 
             is_archive_card = load("common_trello_label__archive") in label_names
-            is_telegram_card = any("Телеграм" in name for name in label_names)
+            is_telegram_card = any(
+                "телеграм" in label.name.lower() for label in card.labels
+            )
 
             missing_fields = []
 


### PR DESCRIPTION
The Телеграм label uses grey-stone (BLACK) color, so it was being excluded from label_names before is_telegram_card was evaluated. Check directly against card.labels instead.