### PR TITLE
fix: upgrade schedule to 1.2.2 to fix timezone-aware at() firing on r…

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -85,7 +85,7 @@ requests-oauthlib==1.3.0
 retrying==1.3.3
 rope==0.17.0
 rsa==4.0
--e git+https://github.com/dbader/schedule.git@3eac646a8d2658929587d7454bd2c85696df254e#egg=schedule
+schedule==1.2.2
 sheetfu==1.5.3
 six==1.14.0
 soupsieve==2.3.2.post1


### PR DESCRIPTION
…estart

The pinned commit of dbader/schedule (1.1.0 era) had a bug in _schedule_next_run: when a timezone was set, it compared self.at_time (in the target TZ, e.g. 20:00 Moscow) against now.time() in local UTC (e.g. 19:35 UTC). Since 20:00 > 19:35, it subtracted 1 day from next_run, landing in the past and causing run_pending() to fire the job immediately on every bot restart.

schedule 1.2.1 and 1.2.2 fix this (see dbader/schedule issues #583, #601-604, #623) by using datetime.now(at_time_zone) throughout.


Claude-Session: https://claude.ai/code/session_01YbEoMDXjYqaE6Vf8g2Cg5S