### PR TITLE
fix: dispatch dev/master deploys to split sysblokbot-testing/prod services

### DIFF
--- a/.github/workflows/publish_dev.yml
+++ b/.github/workflows/publish_dev.yml
@@ -83,4 +83,4 @@ jobs:
           token: ${{ secrets.INFRA_DISPATCH_TOKEN }}
           repository: sysblok/sysblok-infra
           event-type: deploy
-          client-payload: '{"service": "sysblokbot"}'
+          client-payload: '{"service": "sysblokbot-testing"}'

--- a/.github/workflows/publish_master.yml
+++ b/.github/workflows/publish_master.yml
@@ -88,4 +88,4 @@ jobs:
           token: ${{ secrets.INFRA_DISPATCH_TOKEN }}
           repository: sysblok/sysblok-infra
           event-type: deploy
-          client-payload: '{"service": "sysblokbot"}'
+          client-payload: '{"service": "sysblokbot-prod"}'


### PR DESCRIPTION
## Summary
- `publish_dev.yml` and `publish_master.yml` both dispatched `{"service": "sysblokbot"}` to `sysblok-infra` regardless of branch, and that repo's `deploy.yml` force-recreates every container in the `sysblokbot` Compose project on every deploy — so a `dev`-only push (testing image only) was restarting the live prod bot too.
- `publish_dev.yml` now dispatches `service: sysblokbot-testing`; `publish_master.yml` now dispatches `service: sysblokbot-prod`, matching the split done in sysblok/sysblok-infra#32.

## ⚠️ Do not merge yet
Depends on sysblok/sysblok-infra#32, which itself needs a one-time manual data migration on the Hetzner host before it's deployed. Merging this first would make the next `dev`/`master` push dispatch to a service directory that doesn't exist yet on the infra side. Merge only after that PR is merged, the host migration is done, and both bots are confirmed healthy at their new `/srv/sysblokbot-prod` / `/srv/sysblokbot-testing` paths.

## Test plan
- [ ] sysblok-infra PR #32 merged and host migration completed
- [ ] Push a trivial commit to `dev` after merging, confirm only `sysblokbot-testing` restarts (check container uptime/logs), `sysblokbot-prod` unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)