### PR TITLE
Release: sender exception-shadowing fix + prod/testing deploy split

### DIFF
--- a/.github/workflows/publish_dev.yml
+++ b/.github/workflows/publish_dev.yml
@@ -83,4 +83,4 @@ jobs:
           token: ${{ secrets.INFRA_DISPATCH_TOKEN }}
           repository: sysblok/sysblok-infra
           event-type: deploy
-          client-payload: '{"service": "sysblokbot"}'
+          client-payload: '{"service": "sysblokbot-testing"}'

--- a/.github/workflows/publish_master.yml
+++ b/.github/workflows/publish_master.yml
@@ -88,4 +88,4 @@ jobs:
           token: ${{ secrets.INFRA_DISPATCH_TOKEN }}
           repository: sysblok/sysblok-infra
           event-type: deploy
-          client-payload: '{"service": "sysblokbot"}'
+          client-payload: '{"service": "sysblokbot-prod"}'

--- a/src/tg/sender.py
+++ b/src/tg/sender.py
@@ -177,6 +177,11 @@ class TelegramSender(Singleton):
                 return True
             except telegram.error.TelegramError as e:
                 logger.error(f"Could not send a message to {chat_id}", exc_info=e)
+                # Captured now: the "except ... as e" binding is cleared by Python
+                # when its except block exits, and the inner except below rebinds
+                # its own "e" -- reading e.message after the loop would otherwise
+                # raise UnboundLocalError once the inner except has fired.
+                original_error_message = e.message
                 chat_name = AppContext().db_client.get_chat_name(chat_id)
                 for error_logs_recipient in self.error_logs_recipients:
                     try:
@@ -194,16 +199,16 @@ class TelegramSender(Singleton):
                             connect_timeout=SEND_CONNECT_TIMEOUT_SEC,
                             **kwargs,
                         )
-                    except telegram.error.TelegramError as e:
+                    except telegram.error.TelegramError as redirect_error:
                         logger.error(
                             "Could not redirect unsended message "
                             f"to error_logs_recipients {error_logs_recipient}",
-                            exc_info=e,
+                            exc_info=redirect_error,
                         )
 
                 # HTML parse error isn't a separate class in Telegram
                 # So we need to dig into the exception message
-                if "Can't parse entities" in e.message:
+                if "Can't parse entities" in original_error_message:
                     try:
                         # Try sending the plain-text version
                         await self.bot.send_message(


### PR DESCRIPTION
## Summary
- **`src/tg/sender.py`**: fixed an `UnboundLocalError` in the error-handling path — the inner `except ... as e` for the error-log redirect send shadowed the outer send failure's `e`, and Python deletes that binding when its except block exits. Once the redirect send also failed, reading `e.message` afterward crashed, silently swallowing the original error and skipping the plain-text fallback send.
- **`publish_master.yml`**: now dispatches `service: sysblokbot-prod` instead of `service: sysblokbot`, matching the sysblok-infra split (sysblok/sysblok-infra#32) that gives prod and testing independent Compose projects — previously every deploy (including dev-only ones) force-recreated both containers.

## Test plan
- [x] sysblok-infra split deployed and verified live: prod/testing are independent containers, a testing-only deploy no longer restarts prod (container start-time check)
- [x] `sysblokbot-testing` running post-split at revision `05c21ee` (includes the sender.py fix), confirmed healthy via logs
- [ ] After merge, confirm `master` push builds `:prod`, dispatches `service: sysblokbot-prod`, and `sysblokbot-prod` deploys/restarts cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)